### PR TITLE
wasm: make entrypoint configurable

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -33,20 +33,23 @@ import (
 )
 
 type ModuleCommand struct {
-	Command string `json:"command"`
-	Name    string `json:"name"`
-	Code    []byte `json:"code"`
+	Command    string `json:"command"`
+	Name       string `json:"name"`
+	Code       []byte `json:"code"`
+	Entrypoint string `json:"entrypoint,omitempty"`
 }
 
 type loadFlags struct {
-	File string
-	Name string
+	File       string
+	Name       string
+	Entrypoint string
 }
 
 func (c *loadFlags) Flags() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	fs.StringVar(&c.File, "file", "my-module.wasm", "the file path of the loaded Wasm module")
-	fs.StringVar(&c.Name, "name", "my-module", "how to name the loaded Wasm module")
+	fs.StringVar(&c.Name, "name", "", "how to name the loaded Wasm module")
+	fs.StringVar(&c.Entrypoint, "entrypoint", "", "initial function to invoke after loading the Wasm module")
 	return fs
 }
 
@@ -79,9 +82,10 @@ var cmds = []cli.Command{
 			}
 
 			c := ModuleCommand{
-				Command: "load",
-				Name:    name,
-				Code:    code,
+				Command:    "load",
+				Name:       name,
+				Code:       code,
+				Entrypoint: cfg.Entrypoint,
 			}
 
 			return sendCommand(c)


### PR DESCRIPTION
## Description

This PR allows us to specify the entrypoint of the loaded Wasm module (the default is main), something like:

```bash
sudo ./cli/cli load -file wasm_tcp_metadata.wasm -entrypoint _start
```

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
