### PR TITLE
packages: the agent depends on the driver

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ nfpms:
     formats:
       - deb
       - rpm
+    dependencies:
+      - camblet-driver
     contents:
       - dst: /etc/camblet/config.yaml
         src: config.yaml


### PR DESCRIPTION
## Description

The agent itself can't be started without the driver (the driver can be loaded without the agent), so let's draw this dependency relation.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
