### PR TITLE
Add missing kernel dev pack for rhel kernels

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -37,6 +37,7 @@ install_package() {
         enable_epel="--enablerepo=epel"
         # Disable EPEL on Amazon Linux
         grep Amazon /etc/os-release &>/dev/null && enable_epel=""
+        sudo dnf install -y kernel-devel-$(uname -r)
         sudo dnf install ${enable_epel} -y "$1"
     else
         error "Unsupported package manager. Please install packages manually."


### PR DESCRIPTION
## Description

The dnf install camblet command might download a newer version of the Linux headers than the actual one. It causes a failing install since the actual kernel headers are not installed by default. This fix installs the kernel-devel package for the actual running version so the install which also uses uname -r will be able to succeed.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
