### PR TITLE
Add apt update to camblet repo add function

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -49,6 +49,7 @@ add_camblet_repo_and_key() {
     log "Adding Camblet repository and key..."
     if [ -x "$(command -v apt)" ]; then
         # Debian/Ubuntu
+        sudo apt update
         sudo apt install -y wget gnupg linux-headers-$(uname -r) dkms
         sudo sh -c "echo 'deb [signed-by=/etc/apt/trusted.gpg.d/camblet.gpg] $CAMBLET_REPO_URL/packages/deb stable main' > /etc/apt/sources.list.d/camblet.list"
         sudo wget -O /tmp/camblet.asc "$CAMBLET_REPO_URL/packages/camblet.asc"


### PR DESCRIPTION
## Description

On LTS ubuntu with kernel 5.15 the install script fails with: `Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?`
To overcome this sudo apt update was added.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
