### PR TITLE
fix default config dir

### DIFF
--- a/cmd/camblet/build.go
+++ b/cmd/camblet/build.go
@@ -19,13 +19,11 @@
 
 package main
 
-import "os"
-
 // Provisioned by ldflags
 // nolint: gochecknoglobals
 var (
 	version    = "dev"
 	commitHash = "n/a"
 	buildDate  = "unknown"
-	configDir  = func() string { pwd, _ := os.Getwd(); return pwd }() + "/camblet.d"
+	configDir  = "./camblet.d"
 )


### PR DESCRIPTION
## Description

Fixes default built-in config directory setting. The dynamic variable is cannot be overwritten in build time which caused unwanted behaviour.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
