### PR TITLE
Remove all params from Camblet agent deploy

### DIFF
--- a/deploy/camblet.service
+++ b/deploy/camblet.service
@@ -3,7 +3,7 @@ Description=Camblet Agent Service
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/camblet agent --config /etc/camblet/config.yaml --policies-path /etc/camblet/policies --services-path /etc/camblet/services
+ExecStart=/usr/bin/camblet agent
 Restart=always
 User=root
 Group=root


### PR DESCRIPTION
Starting from version 0.6.0, the Camblet agent defaults all these parameters to the correct values.