### PR TITLE
Test packages install after the artifacts upload

### DIFF
--- a/.github/workflows/site-deploy.yaml
+++ b/.github/workflows/site-deploy.yaml
@@ -124,3 +124,10 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
+  
+  test-package:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install camblet-driver and camblet-agent packages
+        run: curl -s https://camblet.io/install.sh | bash


### PR DESCRIPTION
## Description
This PR creates a repository test by installing the uploaded camblet-driver and camblet agent packages right after the upload.
Fixes #135 

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
