### PR TITLE
Add target for running the binary in live edit mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,14 @@ deb: ## Build DEB the meta package
 rpm: ## Build RPM the meta package
 	rpmbuild -ba --define '_rpmdir ./deploy/rpmbuild/' deploy/rpmbuild/SPECS/camblet.spec
 
+.PHONY: _run
+_run: ## Run the binary
+	sudo build/camblet agent --policies-path /etc/camblet/policies/ --services-path /etc/camblet/services/
+
+.PHONY: _sync-config
+_sync-config: ## Sync the configuration files to /etc/camblet
+	$(shell while true; do sudo rsync -av ./camblet.d/ /etc/camblet/; sleep 2; done)
+
 .PHONY: run
-run: ## Run the binary
-	sudo build/camblet agent --policies-path ./camblet.d/policies/ --services-path ./camblet.d/services/
+run: ## Run the binary in live edit mode
+	@$(MAKE) -j2 _run _sync-config


### PR DESCRIPTION
## Description

`make run` now syncs the example service and policy files into the correct place in a VM, so the agent can reload them automatically.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
