### PR TITLE
make: fix run ctrl-c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ _run: ## Run the binary
 
 .PHONY: _sync-config
 _sync-config: ## Sync the configuration files to /etc/camblet
-	$(shell while true; do sudo rsync -av ./camblet.d/ /etc/camblet/; sleep 2; done)
+	watch sudo rsync -av ./camblet.d/ /etc/camblet/ > /dev/null
 
 .PHONY: run
 run: ## Run the binary in live edit mode


### PR DESCRIPTION
## Description

Because of the messed up while sleep loop in #137 we had to Ctrl+C twice to stop `make run`.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
