### PR TITLE
save public ca to file, fix cert permissions

### DIFF
--- a/internal/cli/cmd/agent/agent.go
+++ b/internal/cli/cmd/agent/agent.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"os"
+	"path"
 
 	"emperror.dev/errors"
 	"github.com/bufbuild/protovalidate-go"
@@ -102,6 +103,12 @@ func (c *agentCommand) runCommander(ctx context.Context) error {
 	ca, err := tls.NewCertificateAuthority(caOpts...)
 	if err != nil {
 		return err
+	}
+
+	publicCAPemPath := path.Dir(caPEMPath) + "/public_ca.crt"
+
+	if err := os.WriteFile(publicCAPemPath, ca.GetTrustAnchor().GetPEM(), 0644); err != nil {
+		return errors.WrapIf(err, "could not write CA certificate to file")
 	}
 
 	csrSign, err := commands.CSRSign(ca, c.cli.Configuration().Agent.DefaultCertTTLDuration)


### PR DESCRIPTION
## Description

- save the public certificate from the camblet CA to disc
- Fix the permission of the generated cert (even for already existing ones).

## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
