### PR TITLE
Add CloudNativeSecurityCon banner

### DIFF
--- a/site/landing/src/components/hero.astro
+++ b/site/landing/src/components/hero.astro
@@ -5,8 +5,8 @@ import { Icon } from "astro-icon";
 ---
 
 <main class="flex flex-col items-center lg:pt-28 pb-8 pt-10 mb-20 md:mb-50">
-  <!-- Uncomment and update if news is needed -->
-  <!-- <NewsBanner /> -->
+  <!-- Uncomment and update if news banner is needed -->
+  <NewsBanner />
   <h1
     class="text-center text-5xl lg:text-6xl xl:text-7xl font-bold lg:tracking-tight">
     Kernel Space Access Control for Zero Trust Networking

--- a/site/landing/src/components/newsbanner.astro
+++ b/site/landing/src/components/newsbanner.astro
@@ -1,11 +1,14 @@
 <a
-  href="https://sched.co/1YhDw"
+  href="https://sched.co/1dCTn"
   <div
-  class="flex flex-row gap-3 items-center pl-2 pr-6 py-2 mb-10 md:mb-20 rounded-full bg-blue-300/50 transition hover:scale-105 hover:bg-blue-400">
+  class="flex flex-row gap-3 items-center pl-2 pr-6 py-1.5 mb-10 md:mb-16 rounded-full bg-blue-300/50 transition hover:scale-105 hover:bg-blue-400">
   <button
     type="button"
-    class="rounded-full px-3 bg-white p-0.5 text-sm md:text-base font-bold leading-none flex items-center">
-    New
+    class="rounded-full px-3 bg-white p-1.5 text-sm md:text-base font-bold leading-none flex items-center">
+    June 26-27
   </button>
-  <span class="text-sm md:text-base font-bold">Meet us at Kubecon EU!</span>
+  <span class="text-sm font-bold block md:hidden"> Meet us in Seattle! </span>
+  <span class="text-base font-bold hidden md:block">
+    Meet us at CloudNativeSecurityCon in Seattle!
+  </span>
 </a>


### PR DESCRIPTION
## Description

Add CloudNativeSecurityCon news banner to site with link to the session.

<img width="800" alt="image" src="https://github.com/cisco-open/camblet/assets/14862689/563f6226-5f19-4ad2-8cc0-6c06c7328203">

<img width="434" alt="image" src="https://github.com/cisco-open/camblet/assets/14862689/268f8d83-688e-476a-b2da-cba15a30efc2">
