### PR TITLE
Host only the three latest release and use authentication

### DIFF
--- a/.github/scripts/create_repos.sh
+++ b/.github/scripts/create_repos.sh
@@ -30,7 +30,7 @@ main() {
   while IFS= read -r repo;
   do
     package_name="${repo##*/}"
-    if release_ids=$(curl -fqs -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/${repo}/releases?per_page=100 | jq -r '.[].id')
+    if release_ids=$(curl -fqs -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/${repo}/releases?per_page=3 | jq -r '.[].id')
     then
       for release_id in $release_ids;
       do

--- a/.github/scripts/create_repos.sh
+++ b/.github/scripts/create_repos.sh
@@ -30,12 +30,12 @@ main() {
   while IFS= read -r repo;
   do
     package_name="${repo##*/}"
-    if release_ids=$(curl -fqs https://api.github.com/repos/${repo}/releases?per_page=100 | jq -r '.[].id')
+    if release_ids=$(curl -fqs -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/${repo}/releases?per_page=100 | jq -r '.[].id')
     then
       for release_id in $release_ids;
       do
         echo "Processing release ID: $release_id for $package_name"
-        response=$(curl -fsS https://api.github.com/repos/${repo}/releases/${release_id}/assets)
+        response=$(curl -fsS -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/${repo}/releases/${release_id}/assets)
         curl_status=$?
         if [ $curl_status -ne 0 ]; then
           echo "Curl failed with status: $curl_status"
@@ -53,7 +53,7 @@ main() {
           mkdir -p "${DEB_POOL}/${package_name}"
           pushd "${DEB_POOL}/${package_name}" >/dev/null
           echo "Getting DEB"
-          curl -LOJ -H "Accept: application/octet-stream" "https://api.github.com/repos/${repo}/releases/assets/${deb_asset_id}"
+          curl -LOJ -H "Accept: application/octet-stream" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/${repo}/releases/assets/${deb_asset_id}"
           curl_status=$?
           if [ $curl_status -ne 0 ]; then
             echo "Curl failed with status: $curl_status"
@@ -61,7 +61,6 @@ main() {
           fi
           popd >/dev/null
         done
-        
         rpm_asset_ids=$(echo "$response" | jq -r '.[] | select(.name | endswith(".rpm")) | .id')
         if [ -z "$rpm_asset_ids" ]; then
           echo "No .rpm assets found."
@@ -73,8 +72,8 @@ main() {
           mkdir -p generated_repo/rpm
           pushd generated_repo/rpm >/dev/null
           echo "Getting RPM"
-          rpm_file=$(curl -fqs https://api.github.com/repos/${repo}/releases/assets/${rpm_asset_id} | jq -r '.name')
-          curl -LOJ -H "Accept: application/octet-stream" "https://api.github.com/repos/${repo}/releases/assets/${rpm_asset_id}"
+          rpm_file=$(curl -fqs -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/${repo}/releases/assets/${rpm_asset_id} | jq -r '.name')
+          curl -LOJ -H "Accept: application/octet-stream" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/${repo}/releases/assets/${rpm_asset_id}"
           curl_status=$?
           if [ $curl_status -ne 0 ]; then
             echo "Curl failed with status: $curl_status"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/site-deploy.yaml
+++ b/.github/workflows/site-deploy.yaml
@@ -38,6 +38,8 @@ jobs:
           gpg_private_key: ${{ secrets.PGP_PRIVATE_KEY }}
 
       - name: Build DEB/RPM Repos
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export GPG_FINGERPRINT="${{ steps.import_gpg.outputs.fingerprint }}"
           export ORIGIN="${{ steps.import_gpg.outputs.name }}"

--- a/.github/workflows/site-deploy.yaml
+++ b/.github/workflows/site-deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [site-v2, site]
+    branches: [site-v2]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/site-deploy.yaml
+++ b/.github/workflows/site-deploy.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install required packages
         run: |
@@ -53,7 +53,7 @@ jobs:
           done
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "./generated_repo"
           name: repo
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2
@@ -111,7 +111,7 @@ jobs:
           cp ./deploy/install.sh ./site/landing/dist/install.sh
       
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "./site/landing/dist"
 
@@ -125,7 +125,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
   
   test-package:
     needs: deploy

--- a/.github/workflows/site-deploy.yaml
+++ b/.github/workflows/site-deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [site-v2]
+    branches: [site-v2, site]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description

Because of the GitHub rate limit, we cannot handle releases properly. 
The release was normally killed during only the last test phase, where it was too late since the empty artifacts were already published. This tries to address this by using authentication for every curl issued during the artifact creation process, also it fails as fast as possible to avoid overwriting the artifacts.
Since the size of the file, even with authentication, we are hitting rate limits so from now on we will host only the three latest releases.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)