### PR TITLE
Use download_artifact v4 for compatibility

### DIFF
--- a/.github/workflows/site-deploy.yaml
+++ b/.github/workflows/site-deploy.yaml
@@ -90,7 +90,7 @@ jobs:
           cp -a ./site/docs/dist ./site/landing/dist/docs
 
       - name: Download repo artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: repo
 


### PR DESCRIPTION
## Description
This PR updated the download_artifact to v4. It is required since the v3 is unable to download artifacts uploaded by upload_artifact v4

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)